### PR TITLE
Viz Series and Chapter metadata

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ RUN poetry config virtualenvs.create false
 RUN poetry install --no-dev
 
 COPY viz_manga /app
-ENTRYPOINT [ "python", "./manga.py" ]
+ENTRYPOINT [ "python", "./manga_fetch.py" ]

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ DISCLAIMER: I am not licensed or affiliated with Viz Media and this repository i
 pip install viz_manga
 ```
 
-# Usage
+# CLI Usage
 ```
-usage: manga.py [-h] [--directory DIRECTORY] [--combine] chapter_id
+usage: manga_fetch.py [-h] [--directory DIRECTORY] [--combine] chapter_id
 
 Unobfuscates an entire manga chapter for reading.
 
@@ -24,9 +24,9 @@ options:
   --combine             Combine left and right pages into one image.
 ```
 
-# Example
+## Example
 ```
->>> python manga.py 24297 --directory images/ --combine
+>>> python manga_fetch.py 24297 --directory images/ --combine
 
 INFO:root:Getting 20 pages for One Piece Chapter 1047.0
 Successfully retrieved chapter 24297
@@ -40,5 +40,57 @@ Successfully retrieved chapter 24297
 
 INFO:root:Getting 20 pages for One Piece Chapter 1047.0
 Successfully retrieved chapter 24297
+
+```
+
+# Series and Chapter metadata
+Additionally bundled are scripts to lookup the chapter ids for the fecthing script. The manga details script requires a series slug to lookup available (free) chapters.
+
+## CLI Options
+```
+usage: manga_details.py [-h] {series,chapters} ...
+
+Lookup Viz managa information.
+
+positional arguments:
+  {series,chapters}
+    series           Get series title and slug (for chapter lookup) obtained from the Viz site.
+    chapters         Get chapter title and id obtained from the Viz site.
+
+options:
+  -h, --help         show this help message and exit
+```
+
+## Lookup Manga Series
+```
+>>> python manga_details.py series
+
+{'name': '7thGARDEN', 'slug': '7th-garden'}
+{'name': 'Agravity Boys', 'slug': 'agravity-boys'}
+{'name': 'Akane-banashi', 'slug': 'akane-banashi'}
+{'name': "Akira Toriyama's Manga Theater", 'slug': 'akira-toriyamas-manga-theater'}
+{'name': 'All You Need is Kill', 'slug': 'all-you-need-is-kill-manga'}
+{'name': 'Assassination Classroom', 'slug': 'assassination-classroom'}
+
+```
+
+## Lookup Manga Chapters
+```
+>>> python manga_details.py chapters 7th-garden
+
+{'title': 'ch-1', 'id': '15220', 'link': 'https://www.viz.com/shonenjump/7th-garden-chapter-1/chapter/15220', 'is_free': True}
+{'title': 'ch-2', 'id': '15221', 'link': 'https://www.viz.com/shonenjump/7th-garden-chapter-2/chapter/15221', 'is_free': True}
+{'title': 'ch-3', 'id': '15222', 'link': 'https://www.viz.com/shonenjump/7th-garden-chapter-3/chapter/15222', 'is_free': True}
+{'title': 'ch-4', 'id': '15223', 'link': 'https://www.viz.com/shonenjump/7th-garden-chapter-4/chapter/15223', 'is_free': False}
+{'title': 'ch-5', 'id': '15224', 'link': 'https://www.viz.com/shonenjump/7th-garden-chapter-5/chapter/15224', 'is_free': False}
+
+```
+
+### Get Manga Chapter
+```
+>>> python manga_fetch.py 15220 --directory images/ --combine
+
+INFO:root:Getting 79 pages for Root 1: The Demon's Servant
+Successfully retrieved chapter 15220
 
 ```

--- a/poetry.lock
+++ b/poetry.lock
@@ -21,6 +21,21 @@ tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)"
 tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "cloudpickle"]
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.11.1"
+description = "Screen-scraping library"
+category = "main"
+optional = false
+python-versions = ">=3.6.0"
+
+[package.dependencies]
+soupsieve = ">1.2"
+
+[package.extras]
+html5lib = ["html5lib"]
+lxml = ["lxml"]
+
+[[package]]
 name = "black"
 version = "22.3.0"
 description = "The uncompromising code formatter."
@@ -260,6 +275,14 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
+name = "soupsieve"
+version = "2.3.2.post1"
+description = "A modern CSS selector implementation for Beautiful Soup."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
@@ -303,7 +326,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "26f0e0053037626ef573babfdf26208f0f6b6a51af588a21cbc5c55efb702a57"
+content-hash = "1eda3a2c553f7cb43401ebc19bae1e576b4f7240c11674fc9e3f389b8fb983ce"
 
 [metadata.files]
 atomicwrites = [
@@ -313,6 +336,10 @@ atomicwrites = [
 attrs = [
     {file = "attrs-21.4.0-py2.py3-none-any.whl", hash = "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4"},
     {file = "attrs-21.4.0.tar.gz", hash = "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"},
+]
+beautifulsoup4 = [
+    {file = "beautifulsoup4-4.11.1-py3-none-any.whl", hash = "sha256:58d5c3d29f5a36ffeb94f02f0d786cd53014cf9b3b3951d42e0080d8a9498d30"},
+    {file = "beautifulsoup4-4.11.1.tar.gz", hash = "sha256:ad9aa55b65ef2808eb405f46cf74df7fcb7044d5cbc26487f96eb2ef2e436693"},
 ]
 black = [
     {file = "black-22.3.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:2497f9c2386572e28921fa8bec7be3e51de6801f7459dffd6e62492531c47e09"},
@@ -493,6 +520,10 @@ requests = [
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
+]
+soupsieve = [
+    {file = "soupsieve-2.3.2.post1-py3-none-any.whl", hash = "sha256:3b2503d3c7084a42b1ebd08116e5f81aadfaea95863628c80a3b774a11b7c759"},
+    {file = "soupsieve-2.3.2.post1.tar.gz", hash = "sha256:fc53893b3da2c33de295667a0e19f078c14bf86544af307354de5fcf12a3f30d"},
 ]
 tomli = [
     {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ keywords = ["viz", "manga", "reader"]
 python = "^3.10"
 viz-image-unobfuscate = "^0.1.1"
 requests = "^2.27.1"
+beautifulsoup4 = "^4.11.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"

--- a/viz_manga/__init__.py
+++ b/viz_manga/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '0.1.0'
+__version__ = "0.1.0"
 
 from .manga_fetch import VizMangaFetch

--- a/viz_manga/__init__.py
+++ b/viz_manga/__init__.py
@@ -1,3 +1,3 @@
 __version__ = '0.1.0'
 
-from .manga import VizManga
+from .manga_fetch import VizMangaFetch

--- a/viz_manga/manga_details.py
+++ b/viz_manga/manga_details.py
@@ -1,4 +1,5 @@
-from bs4 import BeautifulSoup
+import re
+from bs4 import BeautifulSoup, ResultSet, Tag
 from requests import Response, Session
 
 
@@ -14,3 +15,13 @@ class VizMangaDetails:
         resp: Response = self.session.get(url)
 
         soup: BeautifulSoup = BeautifulSoup(resp.text, "html.parser")
+        series_section: Tag = soup.find(class_="section_chapters")
+        series_table: Tag = series_section.find("div", {"class":"property-row"})
+        series_tags: ResultSet = series_table.find_all(href=re.compile("/shonenjump/chapters/"), class_="o_chapters-link")
+        for series_tag in series_tags[0:3]:
+            print(series_tag)
+
+
+if __name__ == "__main__":
+    details = VizMangaDetails()
+    details.get_series()

--- a/viz_manga/manga_details.py
+++ b/viz_manga/manga_details.py
@@ -1,5 +1,5 @@
 from bs4 import BeautifulSoup
-from requests import Session
+from requests import Response, Session
 
 
 class VizMangaDetails:

--- a/viz_manga/manga_details.py
+++ b/viz_manga/manga_details.py
@@ -16,10 +16,18 @@ class VizMangaDetails:
 
         soup: BeautifulSoup = BeautifulSoup(resp.text, "html.parser")
         series_section: Tag = soup.find(class_="section_chapters")
-        series_table: Tag = series_section.find("div", {"class":"property-row"})
-        series_tags: ResultSet = series_table.find_all(href=re.compile("/shonenjump/chapters/"), class_="o_chapters-link")
-        for series_tag in series_tags[0:3]:
-            print(series_tag)
+        series_table: Tag = series_section.find("div", {"class": "property-row"})
+
+        series_link_pattern: str = "/shonenjump/chapters/"
+        series_tags: ResultSet = series_table.find_all(
+            href=re.compile(series_link_pattern), class_="o_chapters-link"
+        )
+        for series_tag in series_tags[:]:
+            #print(series_tag)
+            link: str = series_tag["href"]
+            series_slug: str = link.replace(series_link_pattern, "").strip()
+            series_name = series_tag.find_all("div", class_="type-center")[-1].text.strip()
+            print(f"{series_slug}: {series_name}")
 
 
 if __name__ == "__main__":

--- a/viz_manga/manga_details.py
+++ b/viz_manga/manga_details.py
@@ -14,6 +14,14 @@ class Series:
         return f"https://www.viz.com/shonenjump/chapters/{self.slug}"
 
 
+@dataclass
+class Chapter:
+    title: str
+    id: str
+    link: str
+    is_free: bool = False
+
+
 class VizMangaDetails:
     def __init__(self) -> None:
         self.session = Session()
@@ -36,13 +44,61 @@ class VizMangaDetails:
         for series_tag in series_tags:
             link: str = series_tag["href"]
             slug: str = link.replace(series_link_pattern, "").strip()
-            name = series_tag.find_all("div", class_="type-center")[-1].text.strip()
-            
+            name: str = series_tag.find_all("div", class_="type-center")[
+                -1
+            ].text.strip()
+
             series.append(Series(name, slug))
         return sorted(series, key=lambda s: s.name.lower())
 
+    def get_series_chapters(self, series: Series) -> List[Chapter]:
+        resp: Response = self.session.get(series.link)
+
+        chapter_link_pattern: str = "/shonenjump/[^/]+/chapter/(\d+)"
+
+        soup: BeautifulSoup = BeautifulSoup(resp.text, "html.parser")
+        chapter_tags: ResultSet = soup.find_all(
+            lambda tag: tag.name == "a"
+            and "ch-" in tag.get("id", "")
+            and re.search(chapter_link_pattern, tag.get("data-target-url", ""))
+        )
+
+        chapters: List[Chapter] = []
+        for chapter_tag in chapter_tags:
+            link: str = chapter_tag["data-target-url"]
+            match: re.Match = re.search(chapter_link_pattern, link)
+            chapter_id: str = match.group(1)
+            link = f"https://www.viz.com{match.group(0)}"
+
+            name: str = chapter_tag["id"]
+            is_free: bool = "join to read" not in chapter_tag.get("href", "").lower()
+            chapters.append(Chapter(name, chapter_id, link, is_free))
+        return chapters
+
+
 if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Lookup Viz managa information.")
+    subparsers = parser.add_subparsers(dest="command")
+    series_parser = subparsers.add_parser(
+        "series",
+        help="Get series title and slug (for chapter lookup) obtained from the Viz site.",
+    )
+    chapter_parser = subparsers.add_parser(
+        "chapters", help="Get chapter title and id obtained from the Viz site."
+    )
+    chapter_parser.add_argument(
+        "series_slug",
+        help="Series title for which to lookup chapter ids from the Viz site.",
+    )
+
+    args = parser.parse_args()
+
     details = VizMangaDetails()
-    series: List[Series] = details.get_series()
-    for manga in series:
-        print(f"{manga.name} : {manga.slug}")
+    if args.command == "series":
+        series: List[Series] = details.get_series()
+        for manga in series:
+            print(manga.__dict__)
+    elif args.command == "chapters" and args.series_slug:
+        for chapter in details.get_series_chapters(Series(None, args.series_slug)):

--- a/viz_manga/manga_details.py
+++ b/viz_manga/manga_details.py
@@ -8,3 +8,9 @@ class VizMangaDetails:
         self.session.headers = {
             "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.88 Safari/537.36"
         }
+
+    def get_series(self) -> None:
+        url: str = "https://www.viz.com/shonenjump"
+        resp: Response = self.session.get(url)
+
+        soup: BeautifulSoup = BeautifulSoup(resp.text, "html.parser")

--- a/viz_manga/manga_details.py
+++ b/viz_manga/manga_details.py
@@ -1,0 +1,10 @@
+from bs4 import BeautifulSoup
+from requests import Session
+
+
+class VizMangaDetails:
+    def __init__(self) -> None:
+        self.session = Session()
+        self.session.headers = {
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.88 Safari/537.36"
+        }

--- a/viz_manga/manga_details.py
+++ b/viz_manga/manga_details.py
@@ -102,3 +102,4 @@ if __name__ == "__main__":
             print(manga.__dict__)
     elif args.command == "chapters" and args.series_slug:
         for chapter in details.get_series_chapters(Series(None, args.series_slug)):
+            print(chapter.__dict__)

--- a/viz_manga/manga_fetch.py
+++ b/viz_manga/manga_fetch.py
@@ -33,8 +33,6 @@ class VizMangaFetch:
         self.session.headers = {
             "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.88 Safari/537.36"
         }
-        self.session.proxies = {"http": "127.0.0.1:8888", "https": "127.0.0.1:8888"}
-        self.session.verify = False
 
     def _get_manifest(self, chapter_id: int) -> Manifest:
         # if we ask for more pages than are in the chapter, the endpoint will return the max pages

--- a/viz_manga/manga_fetch.py
+++ b/viz_manga/manga_fetch.py
@@ -38,7 +38,7 @@ class VizMangaFetch:
 
     def _get_manifest(self, chapter_id: int) -> Manifest:
         # if we ask for more pages than are in the chapter, the endpoint will return the max pages
-        pages: str = ",".join([str(i) for i in range(25)])
+        pages: str = ",".join([str(i) for i in range(100)])
         url: str = f"https://www.viz.com/manga/get_manga_url?device_id=3&manga_id={chapter_id}&pages={pages}"
         headers: Dict[str, str] = {
             "Referer": "https://www.viz.com/shonenjump/?action=read",
@@ -104,6 +104,8 @@ class VizMangaFetch:
             pages_combine: List[int] = metadata.spreads
 
         for idx_right in pages_combine:
+            if len(page_names) <= idx_right + 1:
+                continue
             filename_left: str = page_names[idx_right + 1]
             filename_right: str = page_names[idx_right]
             filename: str = os.path.join(

--- a/viz_manga/manga_fetch.py
+++ b/viz_manga/manga_fetch.py
@@ -21,11 +21,10 @@ class Metadata:
     pages: List[Any]  # seems to always be empty
 
     spreads: List[int] = field(default_factory=lambda: list())
-    
+
     # only some series chapters have these
     hdwidth: int = -1
     hdheight: int = -1
-
 
 
 class VizMangaFetch:
@@ -66,10 +65,14 @@ class VizMangaFetch:
 
         return image
 
-    def _save_pages(self, chapter_id: int, manifest: Manifest, directory: str) -> List[str]:
+    def _save_pages(
+        self, chapter_id: int, manifest: Manifest, directory: str
+    ) -> List[str]:
         page_names: List[str] = []
         for page_num, url in manifest.pages.items():
-            filename = os.path.join(directory, f"{chapter_id}_page{int(page_num):02d}.jpg")
+            filename = os.path.join(
+                directory, f"{chapter_id}_page{int(page_num):02d}.jpg"
+            )
             image: Image = self._get_page_image(url)
             image.save(filename)
             page_names.append(filename)
@@ -78,13 +81,17 @@ class VizMangaFetch:
     def save_chapter(self, chapter_id: int, directory: str, combine: bool) -> bool:
         manifest: Manifest = self._get_manifest(chapter_id)
         if not manifest or not manifest.metadata_url or not manifest.pages:
-            logging.error(f"Did not find a metadata url or any pages for chapter {chapter_id}, exiting...")
+            logging.error(
+                f"Did not find a metadata url or any pages for chapter {chapter_id}, exiting..."
+            )
             return False
 
         # needs to be done immediated b/c url only signed for 1 sec from when it leaves the Viz server.
         metadata = self._get_metadata(manifest)
         if not metadata:
-            logging.error(f"Could not get metadata for chapter {chapter_id} with {len(manifest.pages)} pages, exiting...")
+            logging.error(
+                f"Could not get metadata for chapter {chapter_id} with {len(manifest.pages)} pages, exiting..."
+            )
             return False
 
         logging.info(f"Getting {len(manifest.pages)} pages for {metadata.title}")

--- a/viz_manga/manga_fetch.py
+++ b/viz_manga/manga_fetch.py
@@ -28,12 +28,14 @@ class Metadata:
 
 
 
-class VizManga:
+class VizMangaFetch:
     def __init__(self) -> None:
         self.session = Session()
         self.session.headers = {
             "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.88 Safari/537.36"
         }
+        self.session.proxies = {"http": "127.0.0.1:8888", "https": "127.0.0.1:8888"}
+        self.session.verify = False
 
     def _get_manifest(self, chapter_id: int) -> Manifest:
         # if we ask for more pages than are in the chapter, the endpoint will return the max pages
@@ -143,7 +145,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
     logging.basicConfig(level=logging.INFO)
-    viz = VizManga()
+    viz = VizMangaFetch()
     if viz.save_chapter(args.chapter_id, args.directory, args.combine):
         print(f"Successfully retrieved chapter {args.chapter_id}")
     else:


### PR DESCRIPTION
# Series and Chapter metadata
Additionally bundled are scripts to lookup the chapter ids for the fecthing script. The manga details script requires a series slug to lookup available (free) chapters.

## CLI Options
```
usage: manga_details.py [-h] {series,chapters} ...

Lookup Viz managa information.

positional arguments:
  {series,chapters}
    series           Get series title and slug (for chapter lookup) obtained from the Viz site.
    chapters         Get chapter title and id obtained from the Viz site.

options:
  -h, --help         show this help message and exit
```

## Lookup Manga Series
```
>>> python manga_details.py series

{'name': '7thGARDEN', 'slug': '7th-garden'}
{'name': 'Agravity Boys', 'slug': 'agravity-boys'}
{'name': 'Akane-banashi', 'slug': 'akane-banashi'}
{'name': "Akira Toriyama's Manga Theater", 'slug': 'akira-toriyamas-manga-theater'}
{'name': 'All You Need is Kill', 'slug': 'all-you-need-is-kill-manga'}
{'name': 'Assassination Classroom', 'slug': 'assassination-classroom'}

```

## Lookup Manga Chapters
```
>>> python manga_details.py chapters 7th-garden

{'title': 'ch-1', 'id': '15220', 'link': 'https://www.viz.com/shonenjump/7th-garden-chapter-1/chapter/15220', 'is_free': True}
{'title': 'ch-2', 'id': '15221', 'link': 'https://www.viz.com/shonenjump/7th-garden-chapter-2/chapter/15221', 'is_free': True}
{'title': 'ch-3', 'id': '15222', 'link': 'https://www.viz.com/shonenjump/7th-garden-chapter-3/chapter/15222', 'is_free': True}
{'title': 'ch-4', 'id': '15223', 'link': 'https://www.viz.com/shonenjump/7th-garden-chapter-4/chapter/15223', 'is_free': False}
{'title': 'ch-5', 'id': '15224', 'link': 'https://www.viz.com/shonenjump/7th-garden-chapter-5/chapter/15224', 'is_free': False}

```

### Get Manga Chapter
```
>>> python manga_fetch.py 15220 --directory images/ --combine

INFO:root:Getting 79 pages for Root 1: The Demon's Servant
Successfully retrieved chapter 15220

```